### PR TITLE
Feature estimate calculation streamline

### DIFF
--- a/src/components/EstimateCreate/EstimateCreate.jsx
+++ b/src/components/EstimateCreate/EstimateCreate.jsx
@@ -34,7 +34,7 @@ export default function EstimateCreate() {
   const showTables = useSelector(store => store.estimatesReducer.tableState);
   const [error, setError] = useState(false);
   const [radioError, setRadioError] = useState("");
-  const {leadtime, setLeadTime} = useState("");
+  const [leadTime, setLeadTime] = useState("");
 
   // ⬇ GET on page load:
   useEffect(() => {
@@ -54,10 +54,17 @@ export default function EstimateCreate() {
 
   //#region ⬇⬇ Event handlers below:
 
-  const timeDifference = (date2, date) => {
-    let diff = (date2.getTime() - date1.getTime()) / 1000;
-    diff /= (60 * 60 * 24 * 7);
-    return Math.abs(Math.round(diff));
+  const timeDifference = (chosenDate) => {
+    // using the chosen date, run the change handler to set estimateData in the reducer for the chosen date
+    handleChange('anticipated_first_pour_date', chosenDate)
+
+    const chosenDateInMilliseconds = Date.parse(chosenDate);
+    const todayInMilliseconds = Date.now();
+    
+    const differenceInSeconds = (chosenDateInMilliseconds - todayInMilliseconds) / 1000;
+    const differenceInWeeks = differenceInSeconds / (60 * 60 * 24 * 7);
+    // set lead time state with a rounded number in weeks
+    setLeadTime(Math.abs(Math.round(differenceInWeeks)));
   }
 
   /** ⬇ handleChange:
@@ -384,7 +391,8 @@ export default function EstimateCreate() {
                       <TableCell><b>Anticipated First Pour Date:</b></TableCell>
                       <TableCell>
                         <TextField
-                          onChange={event => handleChange('anticipated_first_pour_date', event.target.value)}
+                          // run the time difference function with the chosen date when selecting
+                          onChange={event => timeDifference(event.target.value)}
                           required
                           type="date"
                           size="small"
@@ -396,7 +404,7 @@ export default function EstimateCreate() {
                     <TableRow>
                       <TableCell><b>Lead Time (In Weeks):</b></TableCell>
                       <TableCell>
-                        CALC#
+                        {leadTime}
                       </TableCell>
                     </TableRow>
 

--- a/src/components/ImperialTable/ImperialTable.jsx
+++ b/src/components/ImperialTable/ImperialTable.jsx
@@ -75,15 +75,16 @@ export default function ImperialTable() {
   /** ⬇ handleSubmit:
  * When clicked, this will post the object to the DB and send the user back to the dashboard. 
  */
-  const handleSave = event => {
+   const handleSave = event => {
     console.log('In Imperial handleSave');
+    // attach history from useHistory to the estimate object to allow navigation from inside the saga
+    estimateData.history = history;
+
     // ⬇ Don't refresh until submit:
     event.preventDefault();
-    // // ⬇ Sending newPlant to our reducer: 
-    // dispatch({ type: 'ADD_NEW_KIT', payload: newKit });
-    // // ⬇ Send the user back:
-    // history.push('/dashboard');
-  } // End handleSubmit
+    // send the estimate object to be POSTed
+    dispatch({type: 'ADD_ESTIMATE', payload: estimateData})
+  } // End handleSave
 
   const handleCalculateCosts = () => {
     console.log('In Imperial handleCalculateCosts');
@@ -421,7 +422,6 @@ export default function ImperialTable() {
                     <TableRow>
                       <TableCell colSpan={11} align="right">
                         <Button
-                          type="submit"
                           onClick={event => handleCalculateCosts(event)}
                           variant="contained"
                           className={classes.LexendTeraFont11}
@@ -431,7 +431,7 @@ export default function ImperialTable() {
                         </Button>
                         &nbsp; &nbsp;
                         <Button
-                          // type="submit"
+                          type="submit"
                           // ⬇⬇⬇⬇ COMMENT THIS CODE IN/OUT FOR FORM VALIDATION:
                           // onClick={event => handleSave(event)}
                           variant="contained"

--- a/src/components/ImperialTable/ImperialTable.jsx
+++ b/src/components/ImperialTable/ImperialTable.jsx
@@ -44,6 +44,19 @@ export default function ImperialTable() {
   // }, []);
   //#endregion ⬆⬆ All state variables above. 
 
+  // have a useEffect looking at the estimateData object. If all necessary keys exist indicating user has entered all necessary form data,
+  // run the estimate calculations functions to display the rest of the table. This also makes the materials table adjust automatically if the user changes
+  // values
+  useEffect(() => {
+    if (estimateData.square_feet && estimateData.thickness_inches && estimateData.thickened_edge_construction_joint_lineal_feet &&
+        estimateData.thickened_edge_perimeter_lineal_feet && estimateData.primx_flow_dosage_liters && estimateData.primx_steel_fibers_dosage_lbs &&
+        estimateData.primx_cpea_dosage_liters) {
+          // once all the keys exist, run the calculate estimate function and set the table display state for the calculated values
+          const calculatedObject = calculateEstimate(estimateData)
+          setCalculatedDisplayObject(calculatedObject)
+      }
+  }, [estimateData])
+
 
   //#region ⬇⬇ Event handlers below:
   /** ⬇ handleChange:

--- a/src/components/MetricTable/MetricTable.jsx
+++ b/src/components/MetricTable/MetricTable.jsx
@@ -105,7 +105,7 @@ export default function MetricTable() {
 
   return (
     <>
-      <form>
+      <form onSubmit={handleSave}>
         <Grid container
           spacing={2}
           justifyContent="center"
@@ -433,7 +433,7 @@ export default function MetricTable() {
                       </TableCell> */}
                       <TableCell colSpan={11} align="right">
                         <Button
-                          type="submit"
+                          // type="submit"
                           onClick={event => handleCalculateCosts(event)}
                           variant="contained"
                           className={classes.LexendTeraFont11}
@@ -443,9 +443,9 @@ export default function MetricTable() {
                         </Button>
                         &nbsp; &nbsp; 
                         <Button
-                          // type="submit"
+                          type="submit"
                           // ⬇⬇⬇⬇ COMMENT THIS CODE IN/OUT FOR FORM VALIDATION:
-                          onClick={event => handleSave(event)}
+                          // onClick={event => handleSave(event)}
                           variant="contained"
                           className={classes.LexendTeraFont11}
                           color="secondary"

--- a/src/components/MetricTable/MetricTable.jsx
+++ b/src/components/MetricTable/MetricTable.jsx
@@ -82,6 +82,10 @@ export default function MetricTable() {
  */
   const handleSave = event => {
     console.log('In Metric handleSave');
+    // send history along with the estimateData
+    estimateData.history = history;
+
+
     // ⬇ Don't refresh until submit:
     event.preventDefault();
     // send the estimate object to be POSTed

--- a/src/components/MetricTable/MetricTable.jsx
+++ b/src/components/MetricTable/MetricTable.jsx
@@ -49,6 +49,18 @@ export default function MetricTable() {
   //   }, []);
   //   //#endregion ⬆⬆ All state variables above. 
 
+  // have a useEffect looking at the estimateData object. If all necessary keys exist indicating user has entered all necessary form data,
+  // run the estimate calculations functions to display the rest of the table. This also makes the materials table adjust automatically if the user changes
+  // values
+  useEffect(() => {
+    if (estimateData.square_meters && estimateData.thickness_millimeters && estimateData.thickened_edge_construction_joint_lineal_meters &&
+        estimateData.thickened_edge_perimeter_lineal_meters && estimateData.primx_flow_dosage_liters && estimateData.primx_steel_fibers_dosage_kgs &&
+        estimateData.primx_cpea_dosage_liters) {
+          // once all the keys exist, run the calculate estimate function and set the table display state for the calculated values
+          const calculatedObject = calculateEstimate(estimateData)
+          setCalculatedDisplayObject(calculatedObject)
+      }
+  }, [estimateData])
 
   //#region ⬇⬇ Event handlers below:
   /** ⬇ handleChange:

--- a/src/components/MetricTable/MetricTable.jsx
+++ b/src/components/MetricTable/MetricTable.jsx
@@ -82,20 +82,15 @@ export default function MetricTable() {
  */
   const handleSave = event => {
     console.log('In Metric handleSave');
-    // send history along with the estimateData
+    // attach history from useHistory to the estimate object to allow navigation from inside the saga
     estimateData.history = history;
-
 
     // ⬇ Don't refresh until submit:
     event.preventDefault();
     // send the estimate object to be POSTed
     dispatch({type: 'ADD_ESTIMATE', payload: estimateData})
+  } // End handleSave
 
-    // // ⬇ Sending newPlant to our reducer: 
-    // dispatch({ type: 'ADD_NEW_KIT', payload: newKit });
-    // // ⬇ Send the user back:
-    // history.push('/dashboard');
-  } // End handleSubmit
 
   const handleCalculateCosts = () => {
     console.log('In Metric handleCalculateCosts, estimateData:', estimateData);

--- a/src/redux/sagas/licenseeForm.saga.js
+++ b/src/redux/sagas/licenseeForm.saga.js
@@ -31,11 +31,13 @@ function* fetchEstimateQuery(action) {
 function* AddEstimate(action) {
     try {
         const response = yield axios.post('/api/estimates', action.payload);
+        console.log('action payload:', action.payload);
+        
 
         // need to send the user to the search estimates results page using the newly created estimate number
         console.log('response from DB:', response.data);
         // response.data is currently a newly created estimate_number and the licensee_id that was selected for the post
-        
+        yield action.payload.history.push(`/lookup/${response.data.licensee_id}/${response.data.estimate_number}`);
         // yield put({ type: "SET_ESTIMATE" });
     }
 

--- a/src/redux/sagas/licenseeForm.saga.js
+++ b/src/redux/sagas/licenseeForm.saga.js
@@ -31,14 +31,13 @@ function* fetchEstimateQuery(action) {
 function* AddEstimate(action) {
     try {
         const response = yield axios.post('/api/estimates', action.payload);
-        console.log('action payload:', action.payload);
-        
+
+        // action. payload contains the history object from useHistory
+        const history = action.payload.history
 
         // need to send the user to the search estimates results page using the newly created estimate number
-        console.log('response from DB:', response.data);
         // response.data is currently a newly created estimate_number and the licensee_id that was selected for the post
-        yield action.payload.history.push(`/lookup/${response.data.licensee_id}/${response.data.estimate_number}`);
-        // yield put({ type: "SET_ESTIMATE" });
+        yield history.push(`/lookup/${response.data.licensee_id}/${response.data.estimate_number}`);
     }
 
     catch (error) {


### PR DESCRIPTION
Updated Save Estimate button for estimate POST on the Imperial and Metric tables:

Button makes POST dispatch from both metric and imperial views
User is brought to 1.1 estimate view after the POST is successful

Updated Lead Time on Estimate Create view:
Used existing lead time function to display a lead time in weeks between today and the chosen anticipated first pour date

Streamlined Metric and Imperial tables: Calculations run automatically once each form field has an input. This also adjusts automatically if they make changes before submitting estimate.