### PR TITLE
Stretch adjustable waste percentage

### DIFF
--- a/server/routes/estimates.router.js
+++ b/server/routes/estimates.router.js
@@ -101,7 +101,8 @@ router.post('/', (req, res) => {
     thickness_millimeters,
     thickened_edge_perimeter_lineal_meters,
     thickened_edge_construction_joint_lineal_meters,
-    primx_steel_fibers_dosage_kgs
+    primx_steel_fibers_dosage_kgs,
+    waste_factor_percentage
   } = req.body
 
   // create a unique UUID estimate number to use for the estimate being sent
@@ -137,7 +138,8 @@ router.post('/', (req, res) => {
     primx_ultracure_blankets_unit_price,
     primx_cpea_unit_price,
     primx_cpea_shipping_estimate,
-    estimate_number
+    estimate_number,
+    waste_factor_percentage
   ]
 
   // start the query text with shared values
@@ -171,6 +173,7 @@ router.post('/', (req, res) => {
     "primx_cpea_unit_price",
     "primx_cpea_shipping_estimate",
     "estimate_number",
+    "waste_factor_percentage",
   `
   // Add in the imperial or metric specific values based on unit choice
   if (req.body.measurement_units == 'imperial') {
@@ -208,7 +211,7 @@ router.post('/', (req, res) => {
   // add the values clause to the SQL query 
   queryText += `
     VALUES (
-      $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33
+      $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34
       );
   `
   

--- a/src/components/EstimateLookup/EstimateLookup.jsx
+++ b/src/components/EstimateLookup/EstimateLookup.jsx
@@ -405,7 +405,7 @@ export default function EstimateLookup() {
                           </TableRow>
 
                           <TableRow>
-                            <TableCell><b>Waste Factor @ 5%:</b></TableCell>
+                            <TableCell><b>Waste Factor @ {searchResult?.waste_factor_percentage}%:</b></TableCell>
                             <TableCell>
                               {searchResult?.waste_factor_cubic_yards?.toLocaleString('en-US')}
                             </TableCell>
@@ -536,7 +536,7 @@ export default function EstimateLookup() {
                           </TableRow>
 
                           <TableRow>
-                            <TableCell><b>Waste Factor @ 5%:</b></TableCell>
+                            <TableCell><b>Waste Factor @ {searchResult?.waste_factor_percentage}%:</b></TableCell>
                             <TableCell>
                               {searchResult?.waste_factor_cubic_meters?.toLocaleString('en-US')}
                             </TableCell>

--- a/src/components/ImperialTable/ImperialTable.jsx
+++ b/src/components/ImperialTable/ImperialTable.jsx
@@ -260,8 +260,23 @@ export default function ImperialTable() {
                     </TableRow>
 
                     <TableRow>
-                      <TableCell></TableCell>
-                      <TableCell></TableCell>
+                      <TableCell><b>Waste Factor Percentage</b>
+                      </TableCell>
+                      <TableCell>
+                        <TextField
+                          onChange={event => handleChange('waste_factor_percentage', event.target.value)}
+                          required
+                          type="number"
+                          size="small"
+                          InputProps={{
+                            endAdornment: <InputAdornment position="end">%</InputAdornment>,
+                          }}
+                          fullWidth
+                          value={estimateData.waste_factor_percentage}
+                        >
+
+                        </TextField>
+                      </TableCell>
                       <TableCell></TableCell>
                       <TableCell></TableCell>
                       <TableCell><b>PrīmX CPEA @ Dosage Rate per yd³:</b>

--- a/src/components/ImperialTable/ImperialTable.jsx
+++ b/src/components/ImperialTable/ImperialTable.jsx
@@ -273,8 +273,8 @@ export default function ImperialTable() {
                           }}
                           fullWidth
                           value={estimateData.waste_factor_percentage}
+                          onClick={event => dispatch({ type: 'GET_WASTE_FACTOR' })}
                         >
-
                         </TextField>
                       </TableCell>
                       <TableCell></TableCell>

--- a/src/components/MetricTable/MetricTable.jsx
+++ b/src/components/MetricTable/MetricTable.jsx
@@ -269,8 +269,23 @@ export default function MetricTable() {
                     </TableRow>
 
                     <TableRow>
-                      <TableCell></TableCell>
-                      <TableCell></TableCell>
+                      <TableCell><b>Waste Factor Percentage</b>
+                      </TableCell>
+                      <TableCell>
+                        <TextField
+                          onChange={event => handleChange('waste_factor_percentage', event.target.value)}
+                          required
+                          type="number"
+                          size="small"
+                          InputProps={{
+                            endAdornment: <InputAdornment position="end">%</InputAdornment>,
+                          }}
+                          fullWidth
+                          value={estimateData.waste_factor_percentage}
+                          onClick={event => dispatch({ type: 'GET_WASTE_FACTOR' })}
+                        >
+                        </TextField>
+                      </TableCell>
                       <TableCell></TableCell>
                       <TableCell></TableCell>
                       <TableCell><b>PrīmX CPEA @ Dosage Rate per m³:</b>

--- a/src/redux/reducers/estimates.reducer.js
+++ b/src/redux/reducers/estimates.reducer.js
@@ -41,6 +41,11 @@ export const estimatesReducer = (state = {
     // case 'FETCH_ESTIMATE':
     //   return action.payload;
     case 'SET_ESTIMATE':
+      // validation for waste factor percentage: value can't go below 3
+      if (action.payload.key == 'waste_factor_percentage' && action.payload.value < 3) {
+        action.payload.value = 3;
+      }
+
       return {
         ...state,
         [action.payload.key]: action.payload.value

--- a/src/redux/reducers/estimates.reducer.js
+++ b/src/redux/reducers/estimates.reducer.js
@@ -33,7 +33,8 @@ export const estimatesReducer = (state = {
   thickened_edge_perimeter_lineal_meters: "0",
   thickness_millimeters: "",
   thickened_edge_construction_joint_lineal_meters: "0",
-  primx_steel_fibers_dosage_kgs: "40"
+  primx_steel_fibers_dosage_kgs: "40",
+  waste_factor_percentage: 5
 }, action) => {
   switch (action.type) {
     // Commented out deprecated action that's not being used

--- a/src/redux/reducers/snack.reducer.js
+++ b/src/redux/reducers/snack.reducer.js
@@ -85,6 +85,13 @@ const snackReducer = (state = { open: false, message: '', severity: "success" },
         severity: 'info',
         variant: 'filled'
       }
+    case 'GET_WASTE_FACTOR':
+      return {
+        open: true,
+        message: `Enter a percentage to calculate waste factor volume. Default is 5, minimum is 3.`,
+        severity: 'info',
+        variant: 'filled'
+      }
     default:
       return state;
   }


### PR DESCRIPTION
Stretch goal for an adjustable waste percentage is done. Works for both metric and imperial forms, validates to no less that 3%, adjusts as part of the calculations form, and displays the chosen percentage on the 1.1 Estimate Lookup view.